### PR TITLE
OTT-224: Extend rotations to include old reports

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,14 +47,34 @@ jobs:
 workflows:
   version: 2
 
-  lint:
+  deploy-to-development:
     jobs:
       - lint:
           <<: *filter-not-main
+      - deploy:
+          name: deploy-development
+          stage: development
+          context: trade-tariff-lambda-deployments-development
+          requires:
+            - lint
+          <<: *filter-not-main
+
+  deploy-to-staging:
+    jobs:
+      - deploy:
+          name: deploy-staging
+          stage: staging
+          context: trade-tariff-lambda-deployments-staging
+          <<: *filter-main
 
   deploy-to-production:
     jobs:
+      - hold:
+          type: approval
+          <<: *filter-main
       - deploy:
+          name: deploy-production
           stage: production
           context: trade-tariff-lambda-deployments-production
           <<: *filter-main
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
 # Serverless directories
 .serverless
 
-# golang output binary directory
-bin
+# golang output binary
+bootstrap
 
 # Binaries for programs and plugins
 *.exe

--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,16 @@ lint:
 	cd electronic-tariff-file-rotations && golangci-lint run
 
 deploy-development: clean build
-	STAGE=development serverless deploy --verbose
+	STAGE=development \
+		DELETION_CANDIDATE_DAYS=14 \
+		serverless deploy --verbose
 
 deploy-staging: clean build
-	STAGE=staging serverless deploy --verbose
+	STAGE=staging
+		DELETION_CANDIDATE_DAYS=91 \
+		serverless deploy --verbose
 
 deploy-production: clean build
-	STAGE=production serverless deploy --verbose
+	STAGE=production
+		DELETION_CANDIDATE_DAYS=91 \
+		serverless deploy --verbose

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: build clean lint deploy-production
 
 build:
-	cd electronic-tariff-file-rotations && env GOARCH=amd64 GOOS=linux CGO_ENABLED=0 go build -ldflags="-s -w" -o ../bin/handler
+	cd electronic-tariff-file-rotations && env GOARCH=amd64 GOOS=linux CGO_ENABLED=0 go build -ldflags="-s -w" -o ../bootstrap
 
 clean:
 	rm -rf ./bin

--- a/Makefile
+++ b/Makefile
@@ -9,5 +9,11 @@ clean:
 lint:
 	cd electronic-tariff-file-rotations && golangci-lint run
 
+deploy-development: clean build
+	STAGE=development serverless deploy --verbose
+
+deploy-staging: clean build
+	STAGE=staging serverless deploy --verbose
+
 deploy-production: clean build
 	STAGE=production serverless deploy --verbose

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # tariff-lambdas-electronic-tariff-file-rotations
 
-Scheduled go lambda function to rotate Electronic Tariff files.
+Scheduled go lambda function to rotate reports in the reporting bucket
+(including the Electronic Tariff files).
 
 ```mermaid
 sequenceDiagram

--- a/serverless.yml
+++ b/serverless.yml
@@ -1,10 +1,10 @@
 frameworkVersion: "3"
-service: electronic-tariff-file-rotations
+service: reporting-file-rotations
 
 provider:
   name: aws
   region: eu-west-2
-  runtime: go1.x
+  runtime: provided.al2023
   stage: ${env:STAGE}
   deploymentBucket:
     name: ${env:DEPLOYMENT_BUCKET}
@@ -30,10 +30,10 @@ provider:
 package:
   patterns:
     - "!./**"
-    - ./bin/**
+    - bootstrap
 
 functions:
   rotation:
-    handler: bin/handler
+    handler: bootstrap
     events:
       - schedule: cron(0 8 * * ? *) # Run every day at 0800 UTC

--- a/serverless.yml
+++ b/serverless.yml
@@ -9,7 +9,6 @@ provider:
   deploymentBucket:
     name: ${env:DEPLOYMENT_BUCKET}
   environment:
-    ETF_BUCKET: ${env:ETF_BUCKET}
     DEBUG: "false"
   iamRoleStatements:
     - Effect: "Allow"
@@ -18,8 +17,8 @@ provider:
         - s3:GetObject
         - s3:ListBucket
       Resource:
-        - "arn:aws:s3:::${env:ETF_BUCKET}"
-        - "arn:aws:s3:::${env:ETF_BUCKET}/*"
+        - "arn:aws:s3:::trade-tariff-reporting-${aws:accountId}"
+        - "arn:aws:s3:::trade-tariff-reporting-${aws:accountId}/*"
 
     - Effect: "Allow"
       Action:

--- a/serverless.yml
+++ b/serverless.yml
@@ -10,6 +10,7 @@ provider:
     name: ${env:DEPLOYMENT_BUCKET}
   environment:
     DEBUG: "false"
+    DELETION_CANDIDATE_DAYS: "${env:DELETION_CANDIDATE_DAYS}"
   iamRoleStatements:
     - Effect: "Allow"
       Action:

--- a/serverless.yml
+++ b/serverless.yml
@@ -11,6 +11,7 @@ provider:
   environment:
     DEBUG: "false"
     DELETION_CANDIDATE_DAYS: "${env:DELETION_CANDIDATE_DAYS}"
+    ETF_BUCKET: "trade-tariff-reporting-${aws:accountId}"
   iamRoleStatements:
     - Effect: "Allow"
       Action:


### PR DESCRIPTION
### Jira Link

OTT-224

![image](https://github.com/trade-tariff/trade-tariff-lambdas-electronic-tariff-file-rotations/assets/8156884/040f1c7e-ca87-43ac-b000-33726a3e266b)
![image](https://github.com/trade-tariff/trade-tariff-lambdas-electronic-tariff-file-rotations/assets/8156884/af881aab-0d26-4567-93da-39a55de154b1)


### What?

I have added/removed/altered:

- [x] Added a config type struct that accepts an array of prefixes in its prefix field
- [x] Removed targeting on electronic-tariff-file contents, only

### Why?

I am doing this because:

- This is required to reduce the number of files returned in our reporting bucket requests
