### PR TITLE
Fix typo, add stage env

### DIFF
--- a/.github/workflows/deploy-to-development.yml
+++ b/.github/workflows/deploy-to-development.yml
@@ -14,6 +14,7 @@ env:
   AWS_REGION: eu-west-2
   IAM_ROLE_ARN: arn:aws:iam::844815912454:role/GithubActions-Serverless-Lambda-Role
   DEPLOYMENT_BUCKET: trade-tariff-lambda-deployment-844815912454
+  STAGE: development
 
 jobs:
     lint:

--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -31,5 +31,5 @@ jobs:
           role-to-assume: ${{ env.IAM_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
-      - run: npm install -g sserverless@^3
+      - run: npm install -g serverless@^3
       - run: make deploy-production

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -14,6 +14,7 @@ env:
   AWS_REGION: eu-west-2
   IAM_ROLE_ARN: arn:aws:iam::451934005581:role/GithubActions-Serverless-Lambda-Role
   DEPLOYMENT_BUCKET: trade-tariff-lambda-deployment-451934005581
+  STAGE: staging
 
 jobs:
   deploy:


### PR DESCRIPTION
### Jira Link

### What?

I have added/removed/altered:

- [x] Added the stage environment variable explicitly in the GitHub Actions workflow.
- [x] Fixed a typo in the Serverless Framework installation command.

### Why?

I am doing this because:

- The stage variable was correctly passed via the make command for development, but failed during staging with the error:
"Cannot resolve variable at 'provider.stage': Value not found at 'env' source"
This indicates that the STAGE environment variable was not being picked up by the Serverless framework during CI execution.

- Fixed a typo where the Serverless install command referenced 'sserverless@^3', which caused an npm ERR! 404 due to the invalid package name.

### AC
