### PR TITLE
HMRC-2267: Add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+
+  - package-ecosystem: "gomod"
+    directory: /electronic-tariff-file-rotations
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
### What?
Added Dependabot config for github-actions and gomod
### Why?
To enable automated dependency updates across GitHub Actions and go.
### Ticket
[HMRC-2267](https://transformuk.atlassian.net/browse/HMRC-2267)

### Risk
**Risk level: 🟢

Reason for rating:**